### PR TITLE
fix: append message length as bytes not chars

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -53,6 +53,20 @@ try {
   // Get server capabilities
   console.log('Server capabilities:', client.capabilities);
 
+  // Append a new message with multi-byte characters
+  console.log('Appending a new message to INBOX...');
+  await client.appendMessage(
+    'INBOX',
+    'Subject: Special Announcement\r\n' +
+      'From: user@example.com\r\n' +
+      'Date: Fri, 13 Mar 2024 12:00:00 +0000\r\n' +
+      '\r\n' +
+      'Hello! 🌟 Important announcement in English and Chinese (你好)!\r\n',
+    ['\\Seen'], // Mark as read
+    new Date(), // Use current date
+  );
+  console.log('Message appended successfully');
+
   // List available mailboxes
   const mailboxes = await client.listMailboxes();
   console.log('\nAvailable mailboxes:');

--- a/src/commands/mod.ts
+++ b/src/commands/mod.ts
@@ -151,7 +151,8 @@ export function append(
     command += ` ${formatDate(date)}`;
   }
 
-  command += ` {${message.length}}`;
+  const messageBytes = new TextEncoder().encode(message).length;
+  command += ` {${messageBytes}}`;
 
   return command;
 }


### PR DESCRIPTION
Message lengths in IMAP are bytes based not string chars based - have fixed the message length element of the APPEND command function to reflect this. Without this the presence of any multi-byte utf-8 characters in the email body will cause the command to fail.