### PR TITLE
fix: connection cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ new ImapClient(options: ImapOptions)
 
 - `host`: IMAP server hostname
 - `port`: IMAP server port
-- `tls`: Whether to use TLS
+- `tls`: Whether to use TLS (default: true)
 - `username`: Username for authentication
 - `password`: Password for authentication
 - `authMechanism`: Authentication mechanism to use (default: "PLAIN")

--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ new ImapClient(options: ImapOptions)
 - `username`: Username for authentication
 - `password`: Password for authentication
 - `authMechanism`: Authentication mechanism to use (default: "PLAIN")
-- `autoConnect`: Whether to automatically connect on client creation (default: true)
 - `autoReconnect`: Whether to automatically reconnect on connection loss (default: true)
 - `maxReconnectAttempts`: Maximum number of reconnection attempts (default: 3)
 - `reconnectDelay`: Delay between reconnection attempts in milliseconds (default: 1000)

--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ new ImapClient(options: ImapOptions)
   message to a mailbox
 - `forceReconnect()`: Forces a reconnection to the server
 - `updateCapabilities()`: Updates the server capabilities
-- `close()`: Closes the connection (alias for disconnect)
 
 #### Properties
 

--- a/examples/advanced.ts
+++ b/examples/advanced.ts
@@ -43,7 +43,6 @@ const client = new ImapClient({
   tls: Deno.env.get('IMAP_USE_TLS') !== 'false', // Default to true if not explicitly set to false
   username: Deno.env.get('IMAP_USERNAME')!,
   password: Deno.env.get('IMAP_PASSWORD')!,
-  autoConnect: false, // Don't connect automatically
 });
 
 async function main() {

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -91,12 +91,10 @@ try {
     await client.disconnect();
     console.log('\nDisconnected from IMAP server');
   } catch (error) {
-    // If disconnect fails, force close
     console.error(
       'Error during disconnect:',
       error instanceof Error ? error.message : String(error),
     );
-    client.close();
-    console.log('\nForced close of IMAP client');
+    console.log('\nFailed to disconnect cleanly from IMAP server');
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -823,7 +823,7 @@ export class ImapClient {
 
     const tag = this.generateTag();
     const timeoutMs = this.options.commandTimeout || 30000;
-    
+
     const cancellable = createCancellablePromise<void>(
       async () => {
         try {
@@ -844,7 +844,7 @@ export class ImapClient {
           // Wait for the command completion
           while (true) {
             const line = await this.connection.readLine();
-            
+
             if (line.startsWith(tag)) {
               // Command completed
               if (!line.includes('OK')) {
@@ -883,7 +883,7 @@ export class ImapClient {
         }
       },
       timeoutMs,
-      `APPEND command timeout`
+      `APPEND command timeout`,
     );
 
     // Store the cancellable promise for potential early cancellation
@@ -908,7 +908,7 @@ export class ImapClient {
     }
 
     const tag = this.generateTag();
-    
+
     // Create a cancellable timeout promise
     const timeoutMs = this.options.commandTimeout || 30000;
     const cancellable = createCancellablePromise<string[]>(

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,6 +38,7 @@ const DEFAULT_OPTIONS: Partial<ImapOptions> = {
   maxReconnectAttempts: 3,
   reconnectDelay: 1000,
   commandTimeout: 30000,
+  tls: true,
 };
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,7 +34,6 @@ import type {
  * Default options for the IMAP client
  */
 const DEFAULT_OPTIONS: Partial<ImapOptions> = {
-  autoConnect: true,
   autoReconnect: true,
   maxReconnectAttempts: 3,
   reconnectDelay: 1000,
@@ -58,7 +57,10 @@ export class ImapClient {
   /** Whether the client is authenticated */
   private _authenticated = false;
   /** Active command cancellable promises */
-  private activeCommands: Map<string, ReturnType<typeof createCancellablePromise>> = new Map();
+  private activeCommands: Map<
+    string,
+    ReturnType<typeof createCancellablePromise>
+  > = new Map();
   /** Reconnection attempt counter */
   private reconnectAttempts = 0;
   /** Whether a reconnection is in progress */
@@ -71,13 +73,6 @@ export class ImapClient {
   constructor(options: ImapOptions) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.connection = new ImapConnection(this.options);
-
-    if (this.options.autoConnect) {
-      this.connect().catch((error) => {
-        console.error('Failed to auto-connect:', error);
-        // Error is propagated to the caller via the returned promise
-      });
-    }
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -982,8 +982,6 @@ export class ImapClient {
 
       throw error;
     } finally {
-      // Clear the timeout and remove from active commands
-      cancellable.disableTimeout();
       this.activeCommands.delete(tag);
     }
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -134,19 +134,19 @@ export class ImapConnection {
    */
   private async establishConnection(): Promise<void> {
     try {
-      // Create TCP connection
-      this.conn = await Deno.connect({
-        hostname: this.options.host,
-        port: this.options.port,
-      });
-
-      // Upgrade to TLS if needed
       if (this.options.tls) {
+        // Create TLS connection
         this.tlsConn = await Deno.connectTls({
           hostname: this.options.host,
           port: this.options.port,
           caCerts: this.options.tlsOptions?.caCerts,
           alpnProtocols: this.options.tlsOptions?.alpnProtocols,
+        });
+      } else {
+        // Create plain TCP connection
+        this.conn = await Deno.connect({
+          hostname: this.options.host,
+          port: this.options.port,
         });
       }
     } catch (error) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -105,16 +105,13 @@ export class ImapConnection {
       // Wait for the connection to be established or timeout
       await this.connectionTimeoutCancellable.promise;
 
-      // Clear the timeout
-      this.connectionTimeoutCancellable.disableTimeout();
-
       // Start socket activity monitoring
-      this.resetSocketActivity();
+      await this.resetSocketActivity();
 
       this._connected = true;
     } catch (error) {
       // Clean up if connection fails
-      this.disconnect();
+      await this.disconnect();
 
       if (error instanceof ImapError) {
         throw error;
@@ -160,10 +157,14 @@ export class ImapConnection {
    * Resets the socket activity monitor
    * This creates a new cancellable promise that will timeout if no socket activity occurs
    */
-  private resetSocketActivity(): void {
+  private async resetSocketActivity(): Promise<void> {
     // Clear any existing socket activity monitor
     if (this.socketActivityCancellable) {
-      this.socketActivityCancellable.disableTimeout();
+      const promise = this.socketActivityCancellable.promise.catch(() => {
+        // Ignore any errors from cancelled commands
+      });
+      this.socketActivityCancellable.cancel('Resetting socket activity monitor');
+      await promise;
       this.socketActivityCancellable = undefined;
     }
 
@@ -182,10 +183,10 @@ export class ImapConnection {
     );
 
     // When the socket times out, disconnect
-    this.socketActivityCancellable.promise.catch((error) => {
+    this.socketActivityCancellable.promise.catch(async (error) => {
       if (error instanceof ImapTimeoutError) {
         console.log('Socket inactivity timeout, disconnecting');
-        this.disconnect();
+        await this.disconnect();
       }
     });
   }
@@ -193,16 +194,24 @@ export class ImapConnection {
   /**
    * Disconnects from the IMAP server and cleans up resources
    */
-  disconnect(): void {
-    // Clear connection timeout
+  async disconnect(): Promise<void> {
+    // Handle connection timeout cancellable
     if (this.connectionTimeoutCancellable) {
-      this.connectionTimeoutCancellable.disableTimeout();
+      const promise = this.connectionTimeoutCancellable.promise.catch(() => {
+        // Ignore any errors from cancelled commands
+      });
+      this.connectionTimeoutCancellable.cancel('Disconnecting');
+      await promise;
       this.connectionTimeoutCancellable = undefined;
     }
 
-    // Clear socket activity monitor
+    // Handle socket activity cancellable
     if (this.socketActivityCancellable) {
-      this.socketActivityCancellable.disableTimeout();
+      const promise = this.socketActivityCancellable.promise.catch(() => {
+        // Ignore any errors from cancelled commands
+      });
+      this.socketActivityCancellable.cancel('Disconnecting');
+      await promise;
       this.socketActivityCancellable = undefined;
     }
 
@@ -212,11 +221,7 @@ export class ImapConnection {
         this.tlsConn.close();
         this.tlsConn = undefined;
       }
-    } catch (_) {
-      // Ignore errors
-    }
 
-    try {
       if (this.conn) {
         this.conn.close();
         this.conn = undefined;
@@ -242,7 +247,7 @@ export class ImapConnection {
     }
 
     // Reset socket activity monitor
-    this.resetSocketActivity();
+    await this.resetSocketActivity();
 
     const bytes = this.encoder.encode(data);
     const conn = this.tlsConn || this.conn;
@@ -254,7 +259,7 @@ export class ImapConnection {
     try {
       await conn.write(bytes);
     } catch (error) {
-      this.disconnect();
+      await this.disconnect();
       throw new ImapConnectionError(
         'Failed to write to socket',
         error instanceof Error ? error : new Error(String(error)),
@@ -282,7 +287,7 @@ export class ImapConnection {
     }
 
     // Reset socket activity monitor
-    this.resetSocketActivity();
+    await this.resetSocketActivity();
 
     const conn = this.tlsConn || this.conn;
 
@@ -300,7 +305,7 @@ export class ImapConnection {
 
             if (bytesRead === null) {
               // Connection closed
-              this.disconnect();
+              await this.disconnect();
               throw new ImapConnectionError('Connection closed by server');
             }
 
@@ -309,7 +314,7 @@ export class ImapConnection {
           } catch (error) {
             // Handle connection errors
             if (!(error instanceof ImapTimeoutError)) {
-              this.disconnect();
+              await this.disconnect();
             }
             throw error instanceof Error
               ? error
@@ -330,7 +335,7 @@ export class ImapConnection {
     } catch (error) {
       // If it's a timeout error, disconnect and rethrow
       if (error instanceof ImapTimeoutError) {
-        this.disconnect();
+        await this.disconnect();
       }
 
       // Rethrow the error
@@ -363,7 +368,7 @@ export class ImapConnection {
       this.bufferedData = this.bufferedData.substring(crlfIndex + CRLF.length);
 
       // Reset socket activity monitor since we successfully read data
-      this.resetSocketActivity();
+      await this.resetSocketActivity();
 
       return line;
     }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -103,7 +103,11 @@ export class ImapConnection {
       );
 
       // Wait for the connection to be established or timeout
-      await this.connectionTimeoutCancellable.promise;
+      try {
+        await this.connectionTimeoutCancellable.promise;
+      } finally {
+        this.connectionTimeoutCancellable = undefined;
+      }
 
       // Start socket activity monitoring
       await this.resetSocketActivity();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -326,12 +326,7 @@ export class ImapConnection {
       );
 
       // Wait for the read operation to complete or timeout
-      const result = await cancellable.promise;
-
-      // Clear the timeout
-      cancellable.disableTimeout();
-
-      return result;
+      return await cancellable.promise;
     } catch (error) {
       // If it's a timeout error, disconnect and rethrow
       if (error instanceof ImapTimeoutError) {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -7,8 +7,6 @@
  * Options for configuring the IMAP client
  */
 export interface ImapOptions extends ImapConnectionOptions {
-  /** Whether to automatically connect on client creation */
-  autoConnect?: boolean;
   /** Whether to automatically reconnect on connection loss */
   autoReconnect?: boolean;
   /** Maximum number of reconnection attempts */

--- a/src/utils/promises.ts
+++ b/src/utils/promises.ts
@@ -8,28 +8,30 @@ import { ImapTimeoutError } from '../errors.ts';
 /**
  * Creates a cancellable promise with a timeout
  *
- * CAUTION:
- * 1. Resource Management: Always call `disableTimeout()` in a finally block to prevent memory leaks,
- *    especially when the promise might be rejected or cancelled.
+ * The timer is automatically cleared in all of these cases:
+ * - When the promise resolves or rejects (via finally block)
+ * - When the promise is cancelled (via cancel function)
+ * - When the timeout occurs (via timeout handler)
  *
- * 2. Error Handling: The inner promise's rejection will be propagated through the returned promise.
+ * CAUTION:
+ * 1. Error Handling: The inner promise's rejection will be propagated through the returned promise.
  *    Make sure to handle these rejections appropriately.
  *
- * 3. Timeout Behavior: When a timeout occurs, the inner promise continues to execute even though
+ * 2. Timeout Behavior: When a timeout occurs, the inner promise continues to execute even though
  *    the returned promise has already rejected. This can lead to "ghost" operations continuing
  *    in the background. Consider implementing cleanup logic in your promise function.
  *
- * 4. Cancellation: The `cancel()` method only affects the returned promise, not the underlying
+ * 3. Cancellation: The `cancel()` method only affects the returned promise, not the underlying
  *    operation. If you need to cancel the actual operation, you must implement that logic in
  *    your promise function.
  *
- * 5. Connection State: After a timeout, the connection may be in an inconsistent state. It's often
+ * 4. Connection State: After a timeout, the connection may be in an inconsistent state. It's often
  *    best to disconnect and reconnect to ensure a clean slate.
  *
  * @param promiseFn Function that returns a promise to make cancellable
  * @param timeoutMs Timeout in milliseconds
  * @param timeoutMessage Message for the timeout error
- * @returns An object with the promise and functions to cancel or disable the timeout
+ * @returns An object with the promise and functions to cancel
  */
 export function createCancellablePromise<T>(
   promiseFn: () => Promise<T>,
@@ -38,7 +40,6 @@ export function createCancellablePromise<T>(
 ): {
   promise: Promise<T>;
   cancel: (reason?: string) => void;
-  disableTimeout: () => void;
 } {
   let timeoutId: number | undefined;
   let rejectFn: ((reason: Error) => void) | undefined;
@@ -91,9 +92,6 @@ export function createCancellablePromise<T>(
         isSettled = true;
         clearTimer();
       }
-    },
-    disableTimeout: () => {
-      clearTimer();
-    },
+    }
   };
 }

--- a/src/utils/promises.ts
+++ b/src/utils/promises.ts
@@ -92,6 +92,6 @@ export function createCancellablePromise<T>(
         isSettled = true;
         clearTimer();
       }
-    }
+    },
   };
 }

--- a/test/client_test.ts
+++ b/test/client_test.ts
@@ -55,7 +55,6 @@ function createMockClient(): ImapClient {
     username: 'test',
     password: 'test',
     tls: false,
-    autoConnect: false,
   });
 
   // Override the connect method to avoid actual network connection
@@ -598,7 +597,6 @@ Deno.test('ImapClient - Test 8: Operations not allowed without connection', asyn
     username: 'test',
     password: 'test',
     tls: false,
-    autoConnect: false,
   });
 
   // Authenticate without connection

--- a/test/connection_timeout_test.ts
+++ b/test/connection_timeout_test.ts
@@ -24,15 +24,12 @@ Deno.test('ImapConnection - Socket timeout handling', async () => {
 
   // Create a socket activity cancellable that will immediately timeout
   const mockCancellable = {
-    promise: Promise.reject(new ImapTimeoutError('Socket inactivity timeout', 100)),
+    promise: Promise.reject(
+      new ImapTimeoutError('Socket inactivity timeout', 100),
+    ),
     cancel: () => {},
     disableTimeout: () => {},
   };
-
-  // Set up a handler for the promise rejection
-  mockCancellable.promise.catch(() => {
-    // This prevents the unhandled promise rejection
-  });
 
   // Manually trigger disconnect when the timeout occurs
   (connection as any).disconnect = () => {
@@ -63,7 +60,7 @@ Deno.test('ImapConnection - Socket timeout handling', async () => {
   );
 });
 
-Deno.test('ImapConnection - Socket activity reset on operations', () => {
+Deno.test('ImapConnection - Socket activity reset on operations', async () => {
   // Create a connection with mock socket
   const connection = new ImapConnection({
     host: 'localhost',
@@ -76,7 +73,7 @@ Deno.test('ImapConnection - Socket activity reset on operations', () => {
 
   // Mock the socket activity reset
   let activityResetCount = 0;
-  (connection as any).resetSocketActivity = () => {
+  (connection as any).resetSocketActivity = async () => {
     activityResetCount++;
   };
 
@@ -91,14 +88,14 @@ Deno.test('ImapConnection - Socket activity reset on operations', () => {
     },
   };
 
-  // Call the methods directly without awaiting
-  (connection as any).resetSocketActivity();
+  // Call the methods and await
+  await (connection as any).resetSocketActivity();
 
   // Verify activity monitor was reset
   assertEquals(activityResetCount, 1);
 });
 
-Deno.test('ImapConnection - Socket activity cleanup', () => {
+Deno.test('ImapConnection - Socket activity cleanup', async () => {
   // Create a connection
   const connection = new ImapConnection({
     host: 'localhost',
@@ -110,27 +107,24 @@ Deno.test('ImapConnection - Socket activity cleanup', () => {
   });
 
   // Mock the connection and activity monitor
+  let cancelCalled = false;
   (connection as any)._connected = true;
   (connection as any).socketActivityCancellable = {
     promise: Promise.resolve(),
-    cancel: () => {},
+    cancel: () => {
+      cancelCalled = true;
+    },
     disableTimeout: () => {},
   };
   (connection as any).conn = {
     close: () => {},
   };
 
-  // Spy on the disableTimeout method
-  let disableTimeoutCalled = false;
-  (connection as any).socketActivityCancellable.disableTimeout = () => {
-    disableTimeoutCalled = true;
-  };
-
   // Manually disconnect
-  connection.disconnect();
+  await connection.disconnect();
 
   // Verify activity monitor was disabled
-  assertEquals(disableTimeoutCalled, true);
+  assertEquals(cancelCalled, true);
 
   // Verify connection is marked as disconnected
   assertEquals((connection as any)._connected, false);

--- a/test/reconnect_test.ts
+++ b/test/reconnect_test.ts
@@ -48,7 +48,6 @@ function createMockClient(options: {
     username: 'test',
     password: 'test',
     tls: false,
-    autoConnect: false,
     autoReconnect: options.shouldReconnect !== false,
     maxReconnectAttempts: options.reconnectAttempts || 3,
     reconnectDelay: 10, // Use a small delay for faster tests

--- a/test/reconnect_test.ts
+++ b/test/reconnect_test.ts
@@ -304,7 +304,6 @@ Deno.test('ImapClient - Connection timeout in ImapConnection', async () => {
   const mockCancellable = {
     promise: Promise.reject(new ImapTimeoutError('Socket inactivity timeout', 100)),
     cancel: () => {},
-    disableTimeout: () => {},
   };
 
   // Set up a handler for the promise rejection to prevent unhandled rejection

--- a/test/utils/promises_test.ts
+++ b/test/utils/promises_test.ts
@@ -14,12 +14,8 @@ Deno.test('createCancellablePromise - resolves with the result', async () => {
     'Test timeout',
   );
 
-  try {
-    const result = await cancellable.promise;
-    assertEquals(result, expected);
-  } finally {
-    cancellable.disableTimeout();
-  }
+  const result = await cancellable.promise;
+  assertEquals(result, expected);
 });
 
 Deno.test('createCancellablePromise - rejects with the error from the promise', async () => {
@@ -32,15 +28,11 @@ Deno.test('createCancellablePromise - rejects with the error from the promise', 
     'Test timeout',
   );
 
-  try {
-    await assertRejects(
-      () => cancellable.promise,
-      Error,
-      expectedError.message,
-    );
-  } finally {
-    cancellable.disableTimeout();
-  }
+  await assertRejects(
+    () => cancellable.promise,
+    Error,
+    expectedError.message,
+  );
 });
 
 Deno.test('createCancellablePromise - times out if promise takes too long', async () => {
@@ -67,7 +59,6 @@ Deno.test('createCancellablePromise - times out if promise takes too long', asyn
   } finally {
     // Resolve the inner promise to avoid leaking it
     if (resolver) resolver();
-    cancellable.disableTimeout();
   }
 });
 
@@ -98,30 +89,5 @@ Deno.test('createCancellablePromise - can be cancelled', async () => {
   } finally {
     // Resolve the inner promise to avoid leaking it
     if (resolver) resolver();
-    cancellable.disableTimeout();
-  }
-});
-
-Deno.test('createCancellablePromise - disableTimeout prevents timeout', async () => {
-  const timeoutMs = 100;
-
-  const cancellable = createCancellablePromise<string>(
-    async () => {
-      // Use a shorter delay to avoid test timeouts
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      return 'should resolve';
-    },
-    timeoutMs,
-    'Test timeout',
-  );
-
-  // Clear the timeout
-  cancellable.disableTimeout();
-
-  try {
-    const result = await cancellable.promise;
-    assertEquals(result, 'should resolve');
-  } finally {
-    cancellable.disableTimeout(); // Just to be safe
   }
 });


### PR DESCRIPTION
There were a lot of leftovers here I forgot to clean up. This change removes a leftover artifact that was prototyped to allow cleanup during close/disconnect.

* Remove redundant and poorly implemented `close` function in client.ts
* Remove redundant `disableTimeout` in promises.ts
* Remove `autoConnect` footgun that results in promise that can't be awaited
* Cancel inflight promises on disconnect
* Cancel inflight promises when resetting socket activity timeout
* Disconnect is now async and awaited
* ResetSocketActivity is now async and awaited
* TLS is now set to true by default when creating `IMapClient`